### PR TITLE
include .gitignore to generated project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-src/main/g8/.settings/
-src/main/g8/target/
-src/main/g8/.project
-src/main/g8/.classpath
 target/

--- a/src/main/g8/.gitignore
+++ b/src/main/g8/.gitignore
@@ -1,0 +1,12 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.metals
+.bloop
+


### PR DESCRIPTION
Triggered by https://github.com/akka/akka-quickstart-scala.g8/pull/50. Realised that the .gitignore here was not what it should be.